### PR TITLE
Override defaultConfiguration yDocOptions.gc to false

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Elasticsearch } from '@cofacts/hocuspocus-extension-elasticsearch';
 import 'dotenv/config';
 
 const server = Server.configure({
+  yDocOptions: { gc: false, gcFilter: () => true },
   port: process.env.PORT ? Number(process.env.PORT) : 1234,
   extensions: [
     new Logger(),


### PR DESCRIPTION
Accroding to the [doc](https://docs.yjs.dev/api/y.doc)
> Set doc.gc = false to disable garbage collection and be able to restore old content.

We should override Hocuspocus' [defaultConfiguration](https://github.com/ueberdosis/hocuspocus/blob/41de6437e6922e6ad44ccc16e489c925ead7aba4/packages/server/src/Hocuspocus.ts#L31C23-L31C23) to keep the removed content
