### PR TITLE
Ydoc snapshot on server

### DIFF
--- a/hocuspocus-extension-elasticsearch/src/elasticsearch.ts
+++ b/hocuspocus-extension-elasticsearch/src/elasticsearch.ts
@@ -32,7 +32,7 @@ export class Elasticsearch extends Database {
       } catch (e) {
         // console.log(JSON.stringify(e));
         if (e.meta.statusCode !== 404) {
-          console.error(e);
+          console.error('[db]', e);
         }
         return null;
       }
@@ -56,7 +56,7 @@ export class Elasticsearch extends Database {
           },
         });
       } catch (e) {
-        console.error(e);
+        console.error('[db]', e);
       }
     },
   };

--- a/hocuspocus-extension-elasticsearch/src/elasticsearch.ts
+++ b/hocuspocus-extension-elasticsearch/src/elasticsearch.ts
@@ -40,14 +40,19 @@ export class Elasticsearch extends Database {
     store: async ({ documentName, state }) => {
       // console.log(`DB store ${state}`)
       try {
-        await this.db?.index({
+        await this.db?.update({
           index: this.dbIndex,
           type: 'doc',
           id: documentName,
           body: {
-            // elasticsearch stores binary as a Base64 encoded string
-            // https://www.elastic.co/guide/en/elasticsearch/reference/current/binary.html
-            ydoc: state.toString('base64'),
+            doc: {
+              // elasticsearch stores binary as a Base64 encoded string
+              // https://www.elastic.co/guide/en/elasticsearch/reference/current/binary.html
+              ydoc: state.toString('base64'),
+            },
+            upsert: {
+              ydoc: state.toString('base64'),
+            },
           },
         });
       } catch (e) {

--- a/hocuspocus-extension-elasticsearch/src/elasticsearch.ts
+++ b/hocuspocus-extension-elasticsearch/src/elasticsearch.ts
@@ -2,11 +2,7 @@ import {
   Database,
   DatabaseConfiguration,
 } from '@hocuspocus/extension-database';
-import { Document } from '@hocuspocus/server';
 import elasticsearch from '@elastic/elasticsearch';
-import { yDocToProsemirrorJSON } from 'y-prosemirror';
-import { Node } from 'prosemirror-model';
-import { schema } from 'prosemirror-schema-basic';
 
 export interface ElasticsearchConfiguration extends DatabaseConfiguration {
   elasticsearchOpts?: elasticsearch.ClientOptions;
@@ -41,7 +37,7 @@ export class Elasticsearch extends Database {
         return null;
       }
     },
-    store: async ({ documentName, state, document }) => {
+    store: async ({ documentName, state }) => {
       // console.log(`DB store ${state}`)
       try {
         await this.db?.index({
@@ -52,24 +48,6 @@ export class Elasticsearch extends Database {
             // elasticsearch stores binary as a Base64 encoded string
             // https://www.elastic.co/guide/en/elasticsearch/reference/current/binary.html
             ydoc: state.toString('base64'),
-          },
-        });
-
-        // console.log(document.getXmlFragment('prosemirror').toJSON());
-        // output: `<paragraph>First line</paragraph><paragraph>Second line</paragraph>`
-        // We should parse it to plaintext
-        const text = this.docToPlainText(document);
-
-        const now = new Date().toISOString();
-        await this.db?.update({
-          index: 'articles',
-          type: 'doc',
-          id: documentName,
-          body: {
-            doc: {
-              text,
-              updatedAt: now,
-            },
           },
         });
       } catch (e) {
@@ -93,23 +71,5 @@ export class Elasticsearch extends Database {
     this.db = new elasticsearch.Client(elasticsearchOpts);
 
     this.dbIndex = this.configuration.dbIndex || 'ydocs';
-  }
-
-  private docToPlainText(document: Document) {
-    // get prosemirror json
-    const json = yDocToProsemirrorJSON(document);
-    // get prosemirror doc
-    const doc = Node.fromJSON(schema, json);
-    // get plaintext
-    let text = '';
-    doc.content.forEach((node, offset, index) => {
-      // console.log(node.textContent);
-      // console.log(node.type.name);
-      if (node.textContent) {
-        text += node.textContent;
-      }
-      text += '\n';
-    });
-    return text;
   }
 }

--- a/migration/to-v1.0.1-add-version.ts
+++ b/migration/to-v1.0.1-add-version.ts
@@ -1,0 +1,55 @@
+/**
+ * How to use
+ *  1. Make sure reindexed the ydocs using `npm run reload -- ydocs` in rumors-db
+ *  2. Run `npx ts-node --esm .\migration\migrate_to_v1.0.1.ts`
+ */
+
+import { pushVersion } from '../src/snapshot.js';
+import * as Y from 'yjs';
+import elasticsearch from '@elastic/elasticsearch';
+import 'dotenv/config';
+
+const elasticsearchOpts: elasticsearch.ClientOptions = {
+  node: process.env.ELASTICSEARCH_URL,
+};
+
+const client = new elasticsearch.Client(elasticsearchOpts);
+
+async function main() {
+  const size = 1000;
+  let from = 0,
+    total = Infinity;
+
+  while (total > from) {
+    const {
+      body: { hits },
+    } = await client.search({
+      index: 'ydocs',
+      type: 'doc',
+      from,
+      size,
+      body: {
+        query: {
+          match_all: {},
+        },
+      },
+      _source: ['ydoc'],
+    });
+
+    const docs = hits.hits;
+    total = hits.total;
+    from = from + size;
+    console.log(`progress: ${from} / ${total}`);
+    docs.map(({ _id: id, _source: { ydoc: data } }) => {
+      // console.log('id: ', id);
+      const update = Buffer.from(data, 'base64');
+      const doc = new Y.Doc();
+      Y.applyUpdate(doc, update);
+      const snapshot = Y.snapshot(doc);
+      // console.log('snapshot: ', Y.encodeSnapshot(snapshot));
+      pushVersion(id, new Date().toISOString(), Y.encodeSnapshot(snapshot));
+    });
+  }
+}
+
+main().catch(console.error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "hocuspocus-extension-elasticsearch"
       ],
       "dependencies": {
+        "@elastic/elasticsearch": "^6.8.6",
         "@hocuspocus/extension-logger": "^2.0.1",
         "@hocuspocus/server": "^2.0.1",
         "@types/node": "^16.11.11",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node --conditions=hocuspocus_extension_src --no-warnings --loader ts-node/esm --experimental-specifier-resolution=node",
     "dev": "nodemon --inspect -e ts --watch ./src --watch ./hocuspocus-extension-elasticsearch --exec npm start src/index.ts",
-    "prod": "node dist/src/index.js",
+    "prod": "node --experimental-specifier-resolution=node dist/src/index.js",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "build:extension-es": "npm run build -w hocuspocus-extension-elasticsearch",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Cofacts message reporting chatbot and crowd-sourced fact-checking community (「Cofacts 真的假的」訊息回報機器人與查證協作社群)",
   "license": "MIT",
   "dependencies": {
+    "@elastic/elasticsearch": "^6.8.6",
     "@hocuspocus/extension-logger": "^2.0.1",
     "@hocuspocus/server": "^2.0.1",
     "@types/node": "^16.11.11",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,7 @@
-import {
-  Server,
-  Document,
-  onStoreDocumentPayload,
-  afterLoadDocumentPayload,
-} from '@hocuspocus/server';
+import { Server, Document, onStoreDocumentPayload } from '@hocuspocus/server';
 import { Logger } from '@hocuspocus/extension-logger';
 import { Elasticsearch } from '@cofacts/hocuspocus-extension-elasticsearch';
-import { Snapshot, addVersion } from './snapshot';
+import { Snapshot } from './snapshot';
 import { yDocToProsemirrorJSON } from 'y-prosemirror';
 import { Node } from 'prosemirror-model';
 import { schema } from 'prosemirror-schema-basic';
@@ -15,17 +10,6 @@ import 'dotenv/config';
 
 const elasticsearchOpts: elasticsearch.ClientOptions = {
   node: process.env.ELASTICSEARCH_URL,
-};
-
-const afterLoadDocument = async ({ document }: afterLoadDocumentPayload) => {
-  // migration script, for those article had transcript already but didn't have version snapshots
-  if (
-    document.getArray('versions').length === 0 &&
-    document.getXmlFragment('prosemirror').toJSON()
-  ) {
-    console.log('Snapshot doc: ', document.name);
-    addVersion(document);
-  }
 };
 
 const storeArticleText = async (data: onStoreDocumentPayload) => {
@@ -73,7 +57,6 @@ const docToPlainText = (document: Document) => {
 const server = Server.configure({
   yDocOptions: { gc: false, gcFilter: () => true },
   port: process.env.PORT ? Number(process.env.PORT) : 1234,
-  afterLoadDocument,
   onStoreDocument: storeArticleText,
   extensions: [
     new Logger(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,11 +35,7 @@ const storeArticleText = async (data: onStoreDocumentPayload) => {
     // We should parse it to plaintext
     const text = docToPlainText(data.document);
 
-    const db = new elasticsearch.Client(
-      elasticsearchOpts || {
-        node: 'http://localhost:62222',
-      }
-    );
+    const db = new elasticsearch.Client(elasticsearchOpts);
     await db?.update({
       index: 'articles',
       type: 'doc',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Server } from '@hocuspocus/server';
 import { Logger } from '@hocuspocus/extension-logger';
 import { Elasticsearch } from '@cofacts/hocuspocus-extension-elasticsearch';
+import { Snapshot } from './snapshot';
 import 'dotenv/config';
 
 const server = Server.configure({
@@ -8,6 +9,7 @@ const server = Server.configure({
   port: process.env.PORT ? Number(process.env.PORT) : 1234,
   extensions: [
     new Logger(),
+    new Snapshot(),
     new Elasticsearch({
       elasticsearchOpts: { node: process.env.ELASTICSEARCH_URL },
     }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,71 @@
-import { Server } from '@hocuspocus/server';
+import { Server, Document, onStoreDocumentPayload } from '@hocuspocus/server';
 import { Logger } from '@hocuspocus/extension-logger';
 import { Elasticsearch } from '@cofacts/hocuspocus-extension-elasticsearch';
 import { Snapshot } from './snapshot';
+import { yDocToProsemirrorJSON } from 'y-prosemirror';
+import { Node } from 'prosemirror-model';
+import { schema } from 'prosemirror-schema-basic';
+import elasticsearch from '@elastic/elasticsearch';
 import 'dotenv/config';
+
+const elasticsearchOpts: elasticsearch.ClientOptions = {
+  node: process.env.ELASTICSEARCH_URL,
+};
+
+const storeArticleText = async (data: onStoreDocumentPayload) => {
+  try {
+    // console.log(data.document.getXmlFragment('prosemirror').toJSON());
+    // output: `<paragraph>First line</paragraph><paragraph>Second line</paragraph>`
+    // We should parse it to plaintext
+    const text = docToPlainText(data.document);
+
+    const db = new elasticsearch.Client(
+      elasticsearchOpts || {
+        node: 'http://localhost:62222',
+      }
+    );
+    await db?.update({
+      index: 'articles',
+      type: 'doc',
+      id: data.documentName,
+      body: {
+        doc: {
+          text,
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    });
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+const docToPlainText = (document: Document) => {
+  // get prosemirror json
+  const json = yDocToProsemirrorJSON(document);
+  // get prosemirror doc
+  const doc = Node.fromJSON(schema, json);
+  // get plaintext
+  let text = '';
+  doc.content.forEach((node, offset, index) => {
+    // console.log(node.textContent);
+    // console.log(node.type.name);
+    if (node.textContent) {
+      text += node.textContent;
+    }
+    text += '\n';
+  });
+  return text;
+};
 
 const server = Server.configure({
   yDocOptions: { gc: false, gcFilter: () => true },
   port: process.env.PORT ? Number(process.env.PORT) : 1234,
+  onStoreDocument: storeArticleText,
   extensions: [
     new Logger(),
     new Snapshot(),
-    new Elasticsearch({
-      elasticsearchOpts: { node: process.env.ELASTICSEARCH_URL },
-    }),
+    new Elasticsearch({ elasticsearchOpts }),
   ],
 });
 

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -1,0 +1,53 @@
+import { Extension, onDisconnectPayload } from '@hocuspocus/server';
+import * as Y from 'yjs';
+
+export class Snapshot implements Extension {
+  async onDisconnect(data: onDisconnectPayload) {
+    addVersion(data.document);
+  }
+}
+
+/**
+ * Add a snapshot for current doc
+ * ref: https://github.com/yjs/yjs-demos/blob/d8e33e619d6f2da0fae0c6a361286e6901635a9b/prosemirror-versions/prosemirror-versions.js#L26
+ * @param {Y.Doc} doc
+ */
+export const addVersion = (doc: Y.Doc) => {
+  const versions: Y.Array<{
+    date: number;
+    snapshot: Uint8Array;
+  }> = doc.getArray('versions');
+  const prevVersion: {
+    date: number;
+    snapshot: Uint8Array;
+  } = versions.length === 0 ? null : versions.get(versions.length - 1);
+  const prevSnapshot =
+    prevVersion === null
+      ? Y.emptySnapshot
+      : Y.decodeSnapshot(prevVersion.snapshot);
+  const snapshot = Y.snapshot(doc);
+
+  if (!equalSnapshots(doc, prevSnapshot, snapshot)) {
+    // console.log('current clientID: ', doc.clientID);
+    versions.push([
+      {
+        date: new Date().getTime(),
+        snapshot: Y.encodeSnapshot(snapshot),
+      },
+    ]);
+  }
+};
+
+export const equalSnapshots = (
+  doc: Y.Doc,
+  snap1: Y.Snapshot,
+  snap2: Y.Snapshot
+) => {
+  const doc1 = Y.createDocFromSnapshot(doc, snap1);
+  const doc2 = Y.createDocFromSnapshot(doc, snap2);
+
+  return (
+    doc1.getXmlFragment('prosemirror').toString() ===
+    doc2.getXmlFragment('prosemirror').toString()
+  );
+};

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -1,5 +1,7 @@
-import { Extension, onDisconnectPayload } from '@hocuspocus/server';
+import { Extension, onDisconnectPayload, Document } from '@hocuspocus/server';
 import * as Y from 'yjs';
+import elasticsearch from '@elastic/elasticsearch';
+import 'dotenv/config';
 
 export class Snapshot implements Extension {
   async onDisconnect(data: onDisconnectPayload) {
@@ -7,34 +9,33 @@ export class Snapshot implements Extension {
   }
 }
 
+const elasticsearchOpts: elasticsearch.ClientOptions = {
+  node: process.env.ELASTICSEARCH_URL,
+};
+
+const db = new elasticsearch.Client(elasticsearchOpts);
+
 /**
  * Add a snapshot for current doc
  * ref: https://github.com/yjs/yjs-demos/blob/d8e33e619d6f2da0fae0c6a361286e6901635a9b/prosemirror-versions/prosemirror-versions.js#L26
- * @param {Y.Doc} doc
+ * @param {Document} doc
  */
-export const addVersion = (doc: Y.Doc) => {
-  const versions: Y.Array<{
-    date: number;
-    snapshot: Uint8Array;
-  }> = doc.getArray('versions');
+export const addVersion = async (doc: Document) => {
+  const versions: { createdAt: string; snapshot: string }[] = await getVersion(doc);
+  console.log(versions);
   const prevVersion: {
-    date: number;
-    snapshot: Uint8Array;
-  } = versions.length === 0 ? null : versions.get(versions.length - 1);
+    createdAt: string;
+    snapshot: string;
+  } = versions.length === 0 ? null : versions[versions.length - 1];
+  console.log(prevVersion);
   const prevSnapshot =
     prevVersion === null
       ? Y.emptySnapshot
-      : Y.decodeSnapshot(prevVersion.snapshot);
+      : Y.decodeSnapshot(Buffer.from(prevVersion.snapshot, 'base64'));
   const snapshot = Y.snapshot(doc);
 
   if (!equalSnapshots(doc, prevSnapshot, snapshot)) {
-    // console.log('current clientID: ', doc.clientID);
-    versions.push([
-      {
-        date: new Date().getTime(),
-        snapshot: Y.encodeSnapshot(snapshot),
-      },
-    ]);
+    pushVersion(doc.name, new Date().toISOString(), Y.encodeSnapshot(snapshot));
   }
 };
 
@@ -50,4 +51,70 @@ export const equalSnapshots = (
     doc1.getXmlFragment('prosemirror').toString() ===
     doc2.getXmlFragment('prosemirror').toString()
   );
+};
+
+export const getVersion = async (
+  doc: Document
+): Promise<{ createdAt: string; snapshot: string }[]> => {
+  try {
+    // const db = new elasticsearch.Client(elasticsearchOpts);
+    const result = await db?.getSource({
+      index: 'ydocs',
+      id: doc.name,
+      type: 'doc',
+      _source_includes: ['versions'],
+    });
+
+    return result.body?.versions || [];
+  } catch (e) {
+    if (!e.meta) {
+      console.error(e);
+    } else if (e.meta.statusCode !== 404) {
+      console.error(JSON.stringify(e));
+    }
+    return [];
+  }
+};
+
+export const pushVersion = async (
+  docName: string,
+  createdAt: string,
+  snapshot: Uint8Array
+) => {
+  try {
+    const s = Buffer.from(snapshot).toString('base64');
+
+    const version: { createdAt: string; snapshot: string } = {
+      createdAt,
+      snapshot: s,
+    };
+    await db.update({
+      index: 'ydocs',
+      type: 'doc',
+      id: docName,
+      body: {
+        script: {
+          source: `
+              if(ctx._source.versions == null) {
+                ctx._source.versions = [];
+              }
+              ctx._source.versions.add(params.version);
+            `,
+          params: {
+            // elasticsearch stores binary as a Base64 encoded string
+            // https://www.elastic.co/guide/en/elasticsearch/reference/current/binary.html
+            version,
+          },
+          lang: 'painless',
+        },
+        refresh: true,
+      },
+    });
+  } catch (e) {
+    if (!e.meta) {
+      console.error(e);
+    } else if (e.meta.statusCode !== 404) {
+      console.error(JSON.stringify(e));
+    }
+  }
 };

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -68,9 +68,9 @@ export const getVersion = async (
     return result.body?.versions || [];
   } catch (e) {
     if (!e.meta) {
-      console.error(e);
+      console.error('[snapshot]', e);
     } else if (e.meta.statusCode !== 404) {
-      console.error(JSON.stringify(e));
+      console.error('[snapshot]', JSON.stringify(e));
     }
     return [];
   }
@@ -112,9 +112,9 @@ export const pushVersion = async (
     });
   } catch (e) {
     if (!e.meta) {
-      console.error(e);
+      console.error('[snapshot]', e);
     } else if (e.meta.statusCode !== 404) {
-      console.error(JSON.stringify(e));
+      console.error('[snapshot]', JSON.stringify(e));
     }
   }
 };


### PR DESCRIPTION
### Ydoc snapshot 
  - Snapshot when there's a connection closed (if we snapshot onStoreDocument, it will create too mush snapshots)
  - Instead of using [Y.equalSnapshots](https://github.com/yjs/yjs/blob/5ee6992d1fce68993b9a6ea216358d27fc29b294/src/utils/Snapshot.js#L52) which compares whole snapshot including some unnecessary field such as (connected)`users`, we use custom `equalSnapshots` to compare only prosemirror content.
  - [migrate] `index.afterLoadDocument` snapshot for those article had transcript already but didn't have version snapshots

### Migration
- To add a default snapshot to existing ydocs
  Make sure that rumors-db re-indexed to v1.0.1, then run
  ```
  npx ts-node --esm .\migration\migrate_to_v1.0.1.ts
  ```

### Other changes
- Extract storeArticleText logic from elasticsearch extension to index.ts

 