### PR TITLE
Feature/contributor

### DIFF
--- a/hocuspocus-extension-elasticsearch/package.json
+++ b/hocuspocus-extension-elasticsearch/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@elastic/elasticsearch": "^6.8.6",
-    "@hocuspocus/extension-database": "^2.0.1",
+    "@hocuspocus/extension-database": "^2.7.1",
     "y-prosemirror": "^1.2.1",
     "prosemirror-schema-basic": "^1.2.2"
   },

--- a/migration/addContributors.ts
+++ b/migration/addContributors.ts
@@ -1,0 +1,283 @@
+/**
+ * How to use
+ *  1. Make sure reindexed the articles using `npm run reload -- articles` in rumors-db
+ *  2. Run `npx ts-node --esm ./migration/addContributors.ts`
+ */
+
+import * as Y from 'yjs';
+import elasticsearch from '@elastic/elasticsearch';
+import 'dotenv/config';
+
+const elasticsearchOpts: elasticsearch.ClientOptions = {
+  node: process.env.ELASTICSEARCH_URL,
+};
+
+const client = new elasticsearch.Client(elasticsearchOpts);
+const errorArticles = [];
+const usersMap = new Map();
+
+export const getAllContributors = async (
+  articleId: string,
+  document: Y.Doc,
+  versions: { createdAt: string; snapshot: string }[]
+) => {
+  const contributors = new Map();
+  const permanentUserData = new Y.PermanentUserData(document);
+  const yXmlFragment = document.getXmlFragment('prosemirror');
+
+  /**
+   * @param {'removed'|'added'} type
+   * @param {Y.ID} id
+   */
+  const computeYChange = (type: string, id: Y.ID) => {
+    let user =
+      type === 'added'
+        ? permanentUserData.getUserByClientId(id.client)
+        : permanentUserData.getUserByDeletedId(id);
+
+    // fix user === null, item is GCed for unknown reason
+    if (!user) {
+      document.getMap('users')._map.forEach((item, key) => {
+        if (
+          item.content.getContent()[item.length - 1]._item.left?.id.client ===
+          id.client
+        ) {
+          user = key;
+          return;
+        }
+      });
+      // console.log('unknown user: ', { user, type });
+    }
+    return { user, type };
+  };
+
+  for await (const [i, v] of versions.entries()) {
+    const snapshot = Y.decodeSnapshot(Buffer.from(v.snapshot, 'base64'));
+    const versionCreatedAt = v.createdAt;
+    const versionDate = new Date(versionCreatedAt);
+    const prevSnapshot =
+      i > 0
+        ? Y.decodeSnapshot(Buffer.from(versions[i - 1].snapshot, 'base64'))
+        : Y.createSnapshot(Y.createDeleteSet(), new Map());
+
+    for await (const xmlElement of yXmlFragment.toArray()) {
+      const fragmentContent = Y.typeListToArraySnapshot(
+        xmlElement,
+        new Y.Snapshot(prevSnapshot.ds, snapshot.sv)
+      );
+      for await (const f of fragmentContent) {
+        const deltas =
+          f.constructor === Y.XmlText
+            ? f.toDelta(snapshot, prevSnapshot, computeYChange)
+            : undefined;
+        if (deltas) {
+          for await (const d of deltas) {
+            const { attributes } = d;
+            if (attributes && attributes.ychange) {
+              const { user } = attributes.ychange;
+              if (!user) {
+                if (errorArticles.at(-1) !== articleId)
+                  errorArticles.push(articleId);
+                console.log('unknown user in article: ', articleId);
+                continue;
+              }
+
+              // fix user name is number
+              const userId = await getUserId(user.toString());
+              if (!userId) {
+                continue;
+              }
+
+              const contributor = contributors.get(userId);
+              if (
+                !contributor ||
+                versionDate > new Date(contributor.createdAt)
+              ) {
+                contributors.set(userId, {
+                  userId,
+                  updatedAt: versionCreatedAt,
+                  appId: 'WEBSITE',
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return [...contributors.values()];
+};
+
+const forEachYdoc = async (callback) => {
+  let scroll_id,
+    processedCount = 0,
+    total = Infinity;
+
+  const {
+    body: { hits, _scroll_id },
+  } = await client.search({
+    index: 'ydocs',
+    type: 'doc',
+    scroll: '30s',
+    size: 100,
+    body: {
+      query: {
+        match_all: {},
+      },
+    },
+    _source: ['ydoc', 'versions'],
+  });
+
+  await callback(hits.hits);
+
+  processedCount += hits.hits.length;
+  total = hits.total;
+  scroll_id = _scroll_id;
+
+  // eslint-disable-next-line no-console
+  console.info(`${processedCount} / ${total} Processed`);
+  while (processedCount < total) {
+    const {
+      body: { hits, _scroll_id },
+    } = await client.scroll({
+      scroll: '30s',
+      scroll_id, // Fix: Change 'scrollId' to 'scroll_id'
+    });
+
+    await callback(hits.hits);
+
+    processedCount += hits.hits.length;
+    scroll_id = _scroll_id;
+
+    // eslint-disable-next-line no-console
+    console.info(`${processedCount} / ${total} Processed`);
+  }
+};
+
+const getUserId = async (user: string) => {
+  let userId: string;
+  try {
+    const { id } = JSON.parse(user);
+    userId = id;
+  } catch (e) {
+    // console.error('Failed to parse user JSON:', e.message);
+  }
+
+  // ychange user is already userId
+  if (userId) return userId;
+
+  // ychange user is username, use the name to search/get userId
+  try {
+    userId = usersMap.get(user);
+
+    if (userId) return userId;
+
+    const {
+      body: { hits },
+    } = await client.search({
+      index: 'users',
+      type: 'doc',
+      body: {
+        query: {
+          term: {
+            name: user,
+          },
+        },
+      },
+      _source: 'false',
+    });
+    // console.log('hit:', hits);
+    if (hits.hits.length === 1) {
+      userId = hits.hits[0]._id;
+      usersMap.set(user, userId);
+    } else if (hits.hits.length === 0) {
+      // user not found
+      userId = 'USER-NOT-FOUND';
+      usersMap.set(user, userId);
+      console.log('user not found:', user);
+    } else {
+      console.log('Error: User format is incorrect: ', hits, ', user: ', user);
+      userId = undefined;
+    }
+  } catch (searchError) {
+    console.log(
+      'Error occurred while searching for user:',
+      searchError.message
+    );
+    userId = undefined;
+  }
+
+  return userId;
+};
+
+async function main() {
+  // list all ydocs
+  await forEachYdoc(async (hits) => {
+    const operations = [];
+    await Promise.all(
+      hits.map(async ({ _id: id, _source: { ydoc: data, versions } }) => {
+        if (!id || !data || !versions) {
+          // maybe user click the transcribe button but did not save the transcript
+          console.log('ydoc error: id, data or versions null: ', id);
+          errorArticles.push(id);
+          return;
+        }
+
+        const result = await client.getSource({
+          index: 'articles',
+          id,
+          type: 'doc',
+          _source_includes: ['text'],
+        });
+
+        // article text is empty or just '/n'
+        if (!result.body?.text.match(/\S/g)) {
+          // console.log('empty article text: ', id, result);
+          return;
+        }
+
+        // restore the document
+        const update = Buffer.from(data, 'base64');
+        const doc = new Y.Doc({ gc: false });
+        Y.applyUpdate(doc, update);
+
+        const contributors = await getAllContributors(id, doc, versions);
+        // if (contributors.length > 1) console.log('contributors more then 1: ', contributors, id);
+
+        if (contributors.length === 0) {
+          if (errorArticles.at(-1) !== id) errorArticles.push(id);
+          return;
+        }
+        operations.push({
+          update: {
+            _index: 'articles',
+            _type: 'doc',
+            _id: id,
+          },
+        });
+        operations.push({
+          doc: { contributors },
+        });
+      })
+    );
+
+    if (operations.length !== 0) {
+      try {
+        const { body: result } = await client.bulk({
+          body: operations,
+          refresh: 'true',
+          _source: 'false',
+          timeout: '10m',
+        });
+        // console.log('result: ', result);
+      } catch (e) {
+        console.error('error: ', e);
+        throw e;
+      }
+    }
+  });
+  console.log('usersMap: ', usersMap);
+  console.log('errorArticles: ', errorArticles);
+}
+
+main().catch(console.error);

--- a/migration/addContributors.ts
+++ b/migration/addContributors.ts
@@ -10,6 +10,7 @@ import 'dotenv/config';
 
 const elasticsearchOpts: elasticsearch.ClientOptions = {
   node: process.env.ELASTICSEARCH_URL,
+  requestTimeout: 30 * 60 * 1000, // 30 min
 };
 
 const client = new elasticsearch.Client(elasticsearchOpts);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
       ],
       "dependencies": {
         "@elastic/elasticsearch": "^6.8.6",
-        "@hocuspocus/extension-logger": "^2.0.1",
-        "@hocuspocus/server": "^2.0.1",
+        "@hocuspocus/extension-logger": "^2.7.1",
+        "@hocuspocus/server": "^2.7.1",
         "@types/node": "^16.11.11",
         "dotenv": "^16.0.3",
         "yjs": "^13.5.29"
@@ -46,7 +46,7 @@
       "license": "MIT",
       "dependencies": {
         "@elastic/elasticsearch": "^6.8.6",
-        "@hocuspocus/extension-database": "^2.0.1",
+        "@hocuspocus/extension-database": "^2.7.1",
         "prosemirror-schema-basic": "^1.2.2",
         "y-prosemirror": "^1.2.1"
       },
@@ -891,30 +891,30 @@
       }
     },
     "node_modules/@hocuspocus/common": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-2.7.1.tgz",
-      "integrity": "sha512-mnwBn7b2g23rUmYA1+X+FrIwU9aODmRMWe7ypQdjL/MgzlZWrwqFFr0b9u4AhBrwqRTg+L8KCp8SDkpkt2OTtQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-2.11.0.tgz",
+      "integrity": "sha512-u+XxLECnPQCcolUs/svbNal7/1O2phAKsfZ203uI6wJa8ARR9gJoK0avgjPMO0IYHrSzv2mzqhthx7zjQenB3A==",
       "dependencies": {
-        "lib0": "^0.2.47"
+        "lib0": "^0.2.87"
       }
     },
     "node_modules/@hocuspocus/extension-database": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/extension-database/-/extension-database-2.0.6.tgz",
-      "integrity": "sha512-9+/M8oWdhnLAUQF4x1jJEUmZgSqGqKQTqjeWn8u8goBxIgCslyOG6nlnVyF3TO3W3nFNeDFkQWvz7tgwHjSA4A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/extension-database/-/extension-database-2.9.0.tgz",
+      "integrity": "sha512-IoNXxGd1GfUrQ9PjDGF0Dw/xp7f1OMjJJ7x6zubzjrRfWHdJP5tFzMPKirFz95+/W3bd/xQ2gCsfid7E9Ud03g==",
       "dependencies": {
-        "@hocuspocus/server": "^2.0.6"
+        "@hocuspocus/server": "^2.9.0"
       },
       "peerDependencies": {
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.8"
       }
     },
     "node_modules/@hocuspocus/extension-logger": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/extension-logger/-/extension-logger-2.0.6.tgz",
-      "integrity": "sha512-49CaXMFuhtEhKOog82elzTxqOIwHpGy7+AWKQt2/E4gNPT1jEAK57xcz08x066naCc4Kaus7c5Ev8uN8NJNu1Q==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/extension-logger/-/extension-logger-2.11.0.tgz",
+      "integrity": "sha512-J47ie91fDsoMGzRNTIo5dQlPH++nEPOjH/dp3gbU+MJkSrPp4kks7ppVioGnatk8F5AEx9cOSFExFRbrhi5DeQ==",
       "dependencies": {
-        "@hocuspocus/server": "^2.0.6"
+        "@hocuspocus/server": "^2.11.0"
       }
     },
     "node_modules/@hocuspocus/provider": {
@@ -933,11 +933,11 @@
       }
     },
     "node_modules/@hocuspocus/server": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-2.7.1.tgz",
-      "integrity": "sha512-o+LvPZhw9heNkOhkQAa1HdhL2ONwxgpozupekXoPC1Gb5kA+8rZKuGJvPTSI74a6gfhfXvRs7ROvTIVAmQI49g==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-2.11.0.tgz",
+      "integrity": "sha512-ak8R+fWP4yFCcGe8HMr/mtjSiPDSioObUEpvhAylGDsxKXk3mnYXQU9hJ1usCUGqiUMl1rOk1mEg6nVymY9ykA==",
       "dependencies": {
-        "@hocuspocus/common": "^2.7.1",
+        "@hocuspocus/common": "^2.11.0",
         "async-lock": "^1.3.1",
         "kleur": "^4.1.4",
         "lib0": "^0.2.47",
@@ -945,8 +945,8 @@
         "ws": "^8.5.0"
       },
       "peerDependencies": {
-        "y-protocols": "^1.0.5",
-        "yjs": "^13.6.4"
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.8"
       }
     },
     "node_modules/@hocuspocus/transformer": {
@@ -5808,9 +5808,9 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.74",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.74.tgz",
-      "integrity": "sha512-roj9i46/JwG5ik5KNTkxP2IytlnrssAkD/OhlAVtE+GqectrdkfR+pttszVLrOzMDeXNs1MPt6yo66MUolWSiA==",
+      "version": "0.2.88",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.88.tgz",
+      "integrity": "sha512-KyroiEvCeZcZEMx5Ys+b4u4eEBbA1ch7XUaBhYpwa/nPMrzTjUhI4RfcytmQfYoTBPcdyx+FX6WFNIoNuJzJfQ==",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -5819,7 +5819,7 @@
         "0serve": "bin/0serve.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -7968,16 +7968,23 @@
       }
     },
     "node_modules/y-protocols": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.5.tgz",
-      "integrity": "sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
+      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
       "peer": true,
       "dependencies": {
-        "lib0": "^0.2.42"
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
       }
     },
     "node_modules/y18n": {
@@ -8629,7 +8636,7 @@
       "version": "file:hocuspocus-extension-elasticsearch",
       "requires": {
         "@elastic/elasticsearch": "^6.8.6",
-        "@hocuspocus/extension-database": "^2.0.1",
+        "@hocuspocus/extension-database": "^2.7.1",
         "prosemirror-schema-basic": "^1.2.2",
         "tslib": "^2.5.0",
         "y-prosemirror": "^1.2.1"
@@ -8729,27 +8736,27 @@
       "dev": true
     },
     "@hocuspocus/common": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-2.7.1.tgz",
-      "integrity": "sha512-mnwBn7b2g23rUmYA1+X+FrIwU9aODmRMWe7ypQdjL/MgzlZWrwqFFr0b9u4AhBrwqRTg+L8KCp8SDkpkt2OTtQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-2.11.0.tgz",
+      "integrity": "sha512-u+XxLECnPQCcolUs/svbNal7/1O2phAKsfZ203uI6wJa8ARR9gJoK0avgjPMO0IYHrSzv2mzqhthx7zjQenB3A==",
       "requires": {
-        "lib0": "^0.2.47"
+        "lib0": "^0.2.87"
       }
     },
     "@hocuspocus/extension-database": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/extension-database/-/extension-database-2.0.6.tgz",
-      "integrity": "sha512-9+/M8oWdhnLAUQF4x1jJEUmZgSqGqKQTqjeWn8u8goBxIgCslyOG6nlnVyF3TO3W3nFNeDFkQWvz7tgwHjSA4A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/extension-database/-/extension-database-2.9.0.tgz",
+      "integrity": "sha512-IoNXxGd1GfUrQ9PjDGF0Dw/xp7f1OMjJJ7x6zubzjrRfWHdJP5tFzMPKirFz95+/W3bd/xQ2gCsfid7E9Ud03g==",
       "requires": {
-        "@hocuspocus/server": "^2.0.6"
+        "@hocuspocus/server": "^2.9.0"
       }
     },
     "@hocuspocus/extension-logger": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/extension-logger/-/extension-logger-2.0.6.tgz",
-      "integrity": "sha512-49CaXMFuhtEhKOog82elzTxqOIwHpGy7+AWKQt2/E4gNPT1jEAK57xcz08x066naCc4Kaus7c5Ev8uN8NJNu1Q==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/extension-logger/-/extension-logger-2.11.0.tgz",
+      "integrity": "sha512-J47ie91fDsoMGzRNTIo5dQlPH++nEPOjH/dp3gbU+MJkSrPp4kks7ppVioGnatk8F5AEx9cOSFExFRbrhi5DeQ==",
       "requires": {
-        "@hocuspocus/server": "^2.0.6"
+        "@hocuspocus/server": "^2.11.0"
       }
     },
     "@hocuspocus/provider": {
@@ -8764,11 +8771,11 @@
       }
     },
     "@hocuspocus/server": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-2.7.1.tgz",
-      "integrity": "sha512-o+LvPZhw9heNkOhkQAa1HdhL2ONwxgpozupekXoPC1Gb5kA+8rZKuGJvPTSI74a6gfhfXvRs7ROvTIVAmQI49g==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-2.11.0.tgz",
+      "integrity": "sha512-ak8R+fWP4yFCcGe8HMr/mtjSiPDSioObUEpvhAylGDsxKXk3mnYXQU9hJ1usCUGqiUMl1rOk1mEg6nVymY9ykA==",
       "requires": {
-        "@hocuspocus/common": "^2.7.1",
+        "@hocuspocus/common": "^2.11.0",
         "async-lock": "^1.3.1",
         "kleur": "^4.1.4",
         "lib0": "^0.2.47",
@@ -12316,9 +12323,9 @@
       }
     },
     "lib0": {
-      "version": "0.2.74",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.74.tgz",
-      "integrity": "sha512-roj9i46/JwG5ik5KNTkxP2IytlnrssAkD/OhlAVtE+GqectrdkfR+pttszVLrOzMDeXNs1MPt6yo66MUolWSiA==",
+      "version": "0.2.88",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.88.tgz",
+      "integrity": "sha512-KyroiEvCeZcZEMx5Ys+b4u4eEBbA1ch7XUaBhYpwa/nPMrzTjUhI4RfcytmQfYoTBPcdyx+FX6WFNIoNuJzJfQ==",
       "requires": {
         "isomorphic.js": "^0.2.4"
       }
@@ -13928,12 +13935,12 @@
       }
     },
     "y-protocols": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.5.tgz",
-      "integrity": "sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
+      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
       "peer": true,
       "requires": {
-        "lib0": "^0.2.42"
+        "lib0": "^0.2.85"
       }
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "license": "MIT",
   "dependencies": {
     "@elastic/elasticsearch": "^6.8.6",
-    "@hocuspocus/extension-logger": "^2.0.1",
-    "@hocuspocus/server": "^2.0.1",
+    "@hocuspocus/extension-logger": "^2.7.1",
+    "@hocuspocus/server": "^2.7.1",
     "@types/node": "^16.11.11",
     "dotenv": "^16.0.3",
     "yjs": "^13.5.29"

--- a/src/contributors.ts
+++ b/src/contributors.ts
@@ -1,0 +1,129 @@
+import { Extension, Document, onDisconnectPayload } from '@hocuspocus/server';
+import { getVersion, equalSnapshots } from './snapshot';
+import elasticsearch from '@elastic/elasticsearch';
+import 'dotenv/config';
+
+import * as Y from 'yjs';
+const elasticsearchOpts: elasticsearch.ClientOptions = {
+  node: process.env.ELASTICSEARCH_URL,
+};
+const db = new elasticsearch.Client(elasticsearchOpts);
+
+export class Contributors implements Extension {
+  // make sure this extension runs before Snapshot
+  priority = 1000;
+
+  async onDisconnect(data: onDisconnectPayload) {
+    await updateContributors(data);
+  }
+}
+
+// compare current snapshot with previous snapshot to get contributors
+export const getContributorsSinceLastTime = async (document: Document) => {
+  const versions: { createdAt: string; snapshot: string }[] = await getVersion(
+    document
+  );
+  const prevVersion =
+    versions.length === 0 ? null : versions[versions.length - 1];
+
+  const prevSnapshot =
+    prevVersion === null
+      ? Y.emptySnapshot
+      : Y.decodeSnapshot(Buffer.from(prevVersion.snapshot, 'base64'));
+  const snapshot = Y.snapshot(document);
+
+  // use the same createdAt for all contributors in the same snapshot
+  const now = new Date();
+  const contributors = new Map();
+
+  // for computeYChange to get user data
+  const permanentUserData = new Y.PermanentUserData(document);
+  const yXmlFragment = document.getXmlFragment('prosemirror');
+
+  /**
+   * @param {'removed'|'added'} type
+   * @param {Y.ID} id
+   */
+  const computeYChange = (type: string, id: Y.ID) => {
+    const user =
+      type === 'added'
+        ? permanentUserData.getUserByClientId(id.client)
+        : permanentUserData.getUserByDeletedId(id);
+    const userId = JSON.parse(user).id;
+    return {
+      userId,
+      type,
+    };
+  };
+
+  if (equalSnapshots(document, prevSnapshot, snapshot)) return [];
+
+  yXmlFragment.forEach((xmlElement) => {
+    const fragmentContent = Y.typeListToArraySnapshot(
+      xmlElement,
+      new Y.Snapshot(prevSnapshot.ds, snapshot.sv)
+    );
+    fragmentContent.forEach((f) => {
+      const deltas =
+        f.constructor === Y.XmlText
+          ? f.toDelta(snapshot, prevSnapshot, computeYChange)
+          : undefined;
+      deltas.forEach((d) => {
+        const { attributes } = d;
+        if (attributes && attributes.ychange) {
+          const { userId } = attributes.ychange;
+          const contributor = contributors.get(userId);
+          if (!contributor) {
+            contributors.set(userId, {
+              userId,
+              updatedAt: now.toISOString(),
+              appId: 'WEBSITE',
+            });
+          }
+        }
+      });
+    });
+  });
+  return contributors;
+};
+
+export const updateContributors = async (data: onDisconnectPayload) => {
+  try {
+    const contributors = [
+      ...(await getContributorsSinceLastTime(data.document)).values(),
+    ];
+    console.log('contributors: ', contributors);
+    await db?.update({
+      index: 'articles',
+      type: 'doc',
+      id: data.documentName,
+      body: {
+        script: {
+          source: `
+            if (ctx._source.contributors == null) {
+            ctx._source.contributors = [];
+            }
+            
+            def existingContributors = [:];
+            for (def contributor : ctx._source.contributors) {
+                existingContributors[contributor.userId] = contributor;
+            }
+            
+            for (def contributor : params.contributors) {
+                existingContributors[contributor.userId] = contributor;
+            }
+            
+            ctx._source.contributors = existingContributors.values();
+          `,
+          params: {
+            contributors,
+          },
+          lang: 'painless',
+        },
+        refresh: true,
+      },
+    });
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Server, Document, onStoreDocumentPayload } from '@hocuspocus/server';
 import { Logger } from '@hocuspocus/extension-logger';
 import { Elasticsearch } from '@cofacts/hocuspocus-extension-elasticsearch';
 import { Snapshot } from './snapshot';
+import { Contributors } from './contributors';
 import { yDocToProsemirrorJSON } from 'y-prosemirror';
 import { Node } from 'prosemirror-model';
 import { schema } from 'prosemirror-schema-basic';
@@ -11,6 +12,7 @@ import 'dotenv/config';
 const elasticsearchOpts: elasticsearch.ClientOptions = {
   node: process.env.ELASTICSEARCH_URL,
 };
+const db = new elasticsearch.Client(elasticsearchOpts);
 
 const storeArticleText = async (data: onStoreDocumentPayload) => {
   try {
@@ -19,7 +21,6 @@ const storeArticleText = async (data: onStoreDocumentPayload) => {
     // We should parse it to plaintext
     const text = docToPlainText(data.document);
 
-    const db = new elasticsearch.Client(elasticsearchOpts);
     await db?.update({
       index: 'articles',
       type: 'doc',
@@ -62,6 +63,7 @@ const server = Server.configure({
     new Logger(),
     new Snapshot(),
     new Elasticsearch({ elasticsearchOpts }),
+    new Contributors(),
   ],
 });
 


### PR DESCRIPTION
## Changes
- Implement contributors function which compare and update article.contributors since last snapshot
- Upgrade hocuspocus/server to 2.7.1 
  - ref: https://github.com/cofacts/collab-server/pull/6

## Migrate
1. Make sure reindexed the articles using `npm run reload -- articles` in [rumors-db](https://github.com/cofacts/rumors-db/pull/67)
2. Pre-fill `usersMap` with data: const usersMap = new Map([data](https://g0v.hackmd.io/@ZENl3iLKTLaoUuoGPATdbg/HkxTGBgJC))
3. (optional) Start ssh port forwarding `ssh -L 62222:staging.server.path.to:62222 root@staging.server.path.to`
4. Run `npx ts-node --esm ./migration/addContributors.ts`
    - use nodejs 16 or older version of nodejs18

It should output with 9 error articleId including
- 4 are empty transcripts
- 5 are transcripts that have some unknown user, articleIds are
`svXFoosBAjOeMOklEKR3`, `YGoVfIgBvEj1WkaUtc9M`, `CvSJAIsBAjOeMOklKu45`, `Dvfubo0BAjOeMOklG9PK`, `c_YhOowBAjOeMOklCFve`


## Verify result

Elasticsearch query
```
# Can change `must` to `must_not` to check articles that have no contributors.
GET /articles/doc/_search
{
  "size":20,
  "sort" : [
    { "updatedAt" : "desc" }
  ],
  "query": {
    "bool": {
      "must": [
        {
          "nested": {
            "path": "contributors",
            "query": {
              "exists": {
                  "field": "contributors.appId"
              }
            }
          }
        }
      ]
    }
  }
}
```

Or use [graphql api](https://github.com/cofacts/rumors-api/pull/335) to get articles contributed by specific user. 